### PR TITLE
Fix edge label angle on non-square windows

### DIFF
--- a/Visualizer.js
+++ b/Visualizer.js
@@ -84,7 +84,6 @@ export default class Visualizer extends HTMLCanvasElement {
         this.#renderer.render(this.#scene, this.#camera)
     }
 
-    // TODO: Why is rotation slightly off with non-square window?
     #rotateLinkSprites(link) {
         if ("id" in link.source) {
             const source = link.source

--- a/Visualizer.js
+++ b/Visualizer.js
@@ -94,7 +94,7 @@ export default class Visualizer extends HTMLCanvasElement {
             const end = new Vector3(target.x, target.y, target.z).project(this.#camera)
             const delta = end.sub(start)
 
-            link.sprite.material.rotation = Math.atan(delta.y / delta.x)
+            link.sprite.material.rotation = Math.atan2(delta.y, delta.x * this.camera.aspect)
         }
     }
 

--- a/Visualizer.js
+++ b/Visualizer.js
@@ -94,7 +94,7 @@ export default class Visualizer extends HTMLCanvasElement {
             const end = new Vector3(target.x, target.y, target.z).project(this.#camera)
             const delta = end.sub(start)
 
-            link.sprite.material.rotation = Math.atan2(delta.y, delta.x * this.camera.aspect)
+            link.sprite.material.rotation = Math.atan2(delta.y, delta.x * this.#camera.aspect)
         }
     }
 


### PR DESCRIPTION
As promised, fixes #2.

Labels are now aligned with edges even on very wide or tall windows:

![image](https://user-images.githubusercontent.com/10685068/221442438-731b8ef8-2538-4912-9bb5-a66cea9e90e8.png)

![image](https://user-images.githubusercontent.com/10685068/221442465-7b9df4f7-0db6-4cdc-bc43-aedef3cf5077.png)
